### PR TITLE
Modify UI elements

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -4,6 +4,7 @@ import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
@@ -54,6 +55,33 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private StackPane statusbarPlaceholder;
 
+    @FXML
+    private Label allOrdersLabel;
+
+    @FXML
+    private Label todayOrdersLabel;
+
+    @FXML
+    private Label completedLabel;
+
+    @FXML
+    private Label urgentLabel;
+
+    @FXML
+    private Label warehouseLabel;
+
+    @FXML
+    private Label returnLabel;
+
+    @FXML
+    private Label earningLabel;
+
+    @FXML
+    private Label importLabel;
+
+    @FXML
+    private Label settingLabel;
+
     public MainWindow(Stage primaryStage, Logic logic) {
         super(FXML, primaryStage);
 
@@ -81,6 +109,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -100,11 +100,11 @@
 }
 
 .list-cell:filled:even {
-    -fx-background-color: #3c3e3f;
+    -fx-background-color: #faf0e6;
 }
 
 .list-cell:filled:odd {
-    -fx-background-color: #515658;
+    -fx-background-color: #eed9c4;
 }
 
 .list-cell:filled:selected {
@@ -117,7 +117,7 @@
 }
 
 .list-cell .label {
-    -fx-text-fill: white;
+    -fx-text-fill: black;
 }
 
 .cell_big_label {
@@ -137,13 +137,13 @@
 }
 
 .pane-with-border {
-     -fx-background-color: derive(#1d1d1d, 20%);
+     -fx-background-color: derive(white, 10%);
      -fx-border-color: derive(#1d1d1d, 10%);
      -fx-border-top-width: 1px;
 }
 
 .status-bar {
-    -fx-background-color: derive(#1d1d1d, 30%);
+    -fx-background-color: #32406F;
 }
 
 .result-display {
@@ -193,7 +193,7 @@
 }
 
 .menu-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: #32406F;
 }
 
 .menu-bar .label {
@@ -318,9 +318,9 @@
 }
 
 #commandTextField {
-    -fx-background-color: transparent #383838 transparent #383838;
+    -fx-background-color: derive(#32406F, 30%);
     -fx-background-insets: 0;
-    -fx-border-color: #383838 #383838 #ffffff #383838;
+    -fx-border-color: black;
     -fx-border-insets: 0;
     -fx-border-width: 1;
     -fx-font-family: "Segoe UI Light";
@@ -330,6 +330,17 @@
 
 #filterField, #personListPanel, #personWebpage {
     -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
+}
+
+#menuLabels {
+    -fx-background-color: #69779b;
+}
+
+#menuLabels > Label {
+    -fx-padding: 10px;
+    -fx-font-family: "Segoe UI";
+    -fx-text-fill: white;
+    -fx-border-color: #32406F;
 }
 
 #resultDisplay .content {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,16 +3,18 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Delino" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Delino" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -22,38 +24,66 @@
         <URL value="@DarkTheme.css" />
         <URL value="@Extensions.css" />
       </stylesheets>
+         <VBox>
+            <children>
+           <MenuBar fx:id="menuBar">
+             <Menu mnemonicParsing="false" text="File">
+               <MenuItem fx:id="ExitAppItem" mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+             </Menu>
+             <Menu mnemonicParsing="false" text="Help">
+               <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+             </Menu>
+           </MenuBar>
+               <HBox VBox.vgrow="ALWAYS">
+                  <children>
+                     <VBox id="menuLabels" prefHeight="200.0" prefWidth="120.0">
+                        <children>
+                           <Label fx:id="allOrdersLabel" text="All Orders" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                           <Label fx:id="todayOrdersLabel" text="Today's Orders" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                           <Label fx:id="completedLabel" text="Completed" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                           <Label fx:id="urgentLabel" text="Urgent" minWidth="-Infinity" prefWidth="120.0"/>
+                           <Label fx:id="warehouseLabel" text="Warehouse" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                           <Label fx:id="returnLabel" text="Returns" minWidth="-Infinity" prefWidth="120.0"/>
+                           <Label fx:id="earningLabel" text="Earnings" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                           <Label fx:id="importLabel" text="Import" minWidth="-Infinity" prefWidth="120.0"/>
+                           <Label fx:id="settingLabel" text="Settings" minWidth="-Infinity"
+                                  prefWidth="120.0"/>
+                        </children>
+                     </VBox>
+                     <Separator orientation="VERTICAL" prefHeight="200.0" />
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem fx:id="ExitAppItem" mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
+                  <VBox id="userActivityBox" HBox.hgrow="ALWAYS">
 
-        <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
-          <padding>
-            <Insets bottom="5" left="10" right="10" top="5" />
-          </padding>
-        </StackPane>
+                    <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                      <padding>
+                        <Insets bottom="5" left="10" right="10" top="5" />
+                      </padding>
+                    </StackPane>
 
-        <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
-          <padding>
-            <Insets bottom="5" left="10" right="10" top="5" />
-          </padding>
-        </StackPane>
+                    <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                      <padding>
+                        <Insets bottom="5" left="10" right="10" top="5" />
+                      </padding>
+                    </StackPane>
 
-        <VBox fx:id="orderList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets bottom="10" left="10" right="10" top="10" />
-          </padding>
-          <StackPane fx:id="orderListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+                    <VBox fx:id="orderList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                      <padding>
+                        <Insets bottom="10" left="10" right="10" top="10" />
+                      </padding>
+                      <StackPane fx:id="orderListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                    </VBox>
+                  </VBox>
+                  </children>
+               </HBox>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
+                    <StackPane fx:id="statusbarPlaceholder" />
+            </children>
+         </VBox>
     </Scene>
   </scene>
 </fx:root>


### PR DESCRIPTION
This PR modifies the existing UI to the following:
![image](https://user-images.githubusercontent.com/38811217/76957052-15aa3d80-6950-11ea-896a-815bbe773938.png)


Colour scheme adapted from 
http://colormind.io/template/paper-dashboard/#
#F8F8F7, #737D74, #6493EE, #70647D, #32406F
![image](https://user-images.githubusercontent.com/38811217/76957029-09be7b80-6950-11ea-8b4d-449e6170061d.png)

https://colorhunt.co/palette/139181

**Beige colours used**
https://www.color-hex.com/color-palette/9777

**Colours used so far:**
Menu bar #32406F
Label (e.g. All Orders, Today's Orders...) background: #69779b

Even order card (0, 2...) : #faf0e6
Odd order card (1, 3...) : #eed9c4
Obtained from https://www.color-hex.com/color-palette/9777