### PR TITLE
Update the user guide for the warning icon did not appear.

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -296,6 +296,7 @@ transaction id of the parcels and the address of the customers, etc.
 
 ==== Format
 * `import` `FILE_NAME`
+
 [WARNING]
 ====
 * Only csv file could be imported.


### PR DESCRIPTION
Update the user guide for the warning icon did not appear, which will make the user to unable to tell those sentences are warning statement.