### PR TITLE
Modify Postal Code description (UG and DG)

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1621,8 +1621,8 @@ These instructions only provide a starting point for testers to work on; testers
    Expected: The second index phone number is changed to 9952 1654
 .. Test case: `edit` `1` `a/Blk 123 Pasir Ris street 51 #12-23 S510123` +
    Expected: The first index is edited where the address of the customer of the order will be changed to Blk 123 Pasir Ris Street 51 #12-23 S510123
-.. Test case: `edit` `2` `n/Mr Tan` `p/98776655` `a/Blk 888 Jurong East street 2 #01-02 S521731` +
-   Expected: The first index of the list is edited. The name is changed to Mr Tan, phone number changed to 98776655 and address will be changed to Blk 888 Jurong East street 2 #01-02 S521731
+.. Test case: `edit` `2` `n/Mr Tan` `p/98776655` `a/Blk 888 Jurong East street 2 #01-02 S609601` +
+   Expected: The second index of the list is edited. The name is changed to Mr Tan, phone number changed to 98776655 and address will be changed to Blk 888 Jurong East street 2 #01-02 S609601
 .. Test case: `edit` `1` `ts/09/08/2020` +
    Expected: The delivery date of the first index of the customer will be rescheduled to 09/08/2020
 .. Test case: `edit` `1` `ts/02/02/2020` (Assuming this date has passed) +

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -595,7 +595,7 @@ There are two different scenarios on how to insert the orders :
 |Scenario |Command |Result
 
 | Insert the order without a comment and no item type
-| `insert` `tid/A094844` `n/John Doe` `a/Blk 505 Tampines #10-33 S469695` `p/98761111` `e/johndoe@example.com` `dts/2020-05-20 1300` `w/Yishun` `cod/$4`
+| `insert` `tid/A094844` `n/John Doe` `a/Blk 505 Tampines #10-33 S520505` `p/98761111` `e/johndoe@example.com` `dts/2020-05-20 1300` `w/Yishun` `cod/$4`
 | You should be able to see that the order with transaction id 'A094844' will be inserted into the list of delivery orders.
 
 | Insert the order with all the order attributes including the non-compulsory ones
@@ -656,7 +656,7 @@ ot/ORDER_TYPE, tid/TRANSACTION_ID, n/NAME, a/ADDRESS, p/PHONE_NUMBER, e/EMAIL, d
 .Return data format
 |===
 ot/ORDER_TYPE,tid/TRANSACTION_ID, n/NAME, a/ADDRESS, p/PHONE_NUMBER, e/EMAIL, rts/RETURN_DATE_&_TIME, w/WAREHOUSE_LOCATION, [c/COMMENTS_BY_CUSTOMER], [type/TYPE_OF_ITEM]
-`ot/return`,`tid/b1230512`,`n/Aaron Teo`,`a/256 Alpha Road #03-22 S123567`,`p/91230456`, `e/aaron@example.com`, `rts/2020-05-10 1400`,`w/Jurong Warehouse`,`c/Leave it at the lobby`,`type/metal`
+`ot/return`,`tid/b1230512`,`n/Aaron Teo`,`a/Seletar S797580`,`p/91230456`, `e/aaron@example.com`, `rts/2020-05-10 1400`,`w/Jurong Warehouse`,`c/Leave it at the lobby`,`type/metal`
 |===
 
 [NOTE]

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -117,7 +117,7 @@
 }
 
 .list-cell:filled:selected {
-    -fx-background-color: #424d5f;
+    -fx-background-color: derive(-fx-secondary, 80%);
 }
 
 .list-cell:filled:selected #cardPane {


### PR DESCRIPTION
This PR modifies the following:
1. Colour for selected cell in Ui list view (.list-cell:filled:selected)
2. DG and UG postal codes (to match their corresponding description)