### PR TITLE
Update DeleteCommandParser error messages and parsing of flags

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -20,5 +20,6 @@ public class Messages {
         "There is no cash on delivery field in Return order please check your input.";
     public static final String MESSAGE_ORDERS_LISTED_OVERVIEW = "%d order(s) listed!";
     public static final String MESSAGE_RETURN_ORDERS_LISTED_OVERVIEW = "%d return order(s) listed!";
+    public static final String MESSAGE_MISSING_INDEX = "Please provide an index!";
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -43,8 +43,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
     }
 
+    /**
+     * Checks if there is a valid index value in {@code removeFlagString}.
+     */
     private void hasIndex(String removeFlagString) throws ParseException {
         if (removeFlagString.trim().length() == 0) {
+            logger.info(String.format("Invalid arguments given for hasIndex function: %s", removeFlagString));
             throw new ParseException(MESSAGE_MISSING_INDEX);
         }
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,13 +1,19 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_MISSING_FLAG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_ORDER_BOOK;
 import static seedu.address.logic.parser.CliSyntax.FLAG_RETURN_BOOK;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import seedu.address.logic.commands.DeleteCommand;
 
@@ -19,8 +25,40 @@ import seedu.address.logic.commands.DeleteCommand;
  * therefore should be covered by the ParserUtilTest.
  */
 public class DeleteCommandParserTest {
-
+    private String newline = System.lineSeparator();
     private DeleteCommandParser parser = new DeleteCommandParser();
+
+    /**
+     * Generate a stream of invalid flag arguments for testing.
+     *
+     * @return Stream of arguments representing invalid flag arguments
+     */
+    private static Stream<Arguments> invalidFlagArgs() {
+        return Stream.of(
+                Arguments.of("a"),
+                Arguments.of("-f 1"),
+                Arguments.of("-flag_invalid "),
+                Arguments.of("    no   valid arg ")
+        );
+    }
+
+    /**
+     * Generate a stream of invalid index arguments for testing.
+     *
+     * @return Stream of arguments representing invalid index arguments
+     */
+    private static Stream<Arguments> invalidIndexArgs() {
+        return Stream.of(
+                Arguments.of("1-r -r"),
+                Arguments.of("-o 1-r"),
+                Arguments.of("1-o -o"),
+                Arguments.of("-o 1-o"),
+                Arguments.of("a -o"),
+                Arguments.of("-o a"),
+                Arguments.of("a -r"),
+                Arguments.of("-r a")
+        );
+    }
 
     @Test
     public void parse_validArgsOrderBook_returnsDeleteCommand() {
@@ -29,14 +67,38 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_invalidIndexOrderBook_throwsParseException() {
+        assertParseFailure(parser, "-o a",
+                String.format(MESSAGE_INVALID_INDEX + newline + "%s", DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_validArgsReturnBook_returnsDeleteCommand() {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ORDER, FLAG_RETURN_BOOK);
         assertParseSuccess(parser, "-r 1", deleteCommand);
     }
 
-    @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    /**
+     * Tests parse method with invalid index argument.
+     *
+     * @param args obtained from method {@code invalidIndexArgs}
+     */
+    @ParameterizedTest
+    @MethodSource("invalidIndexArgs")
+    public void parse_invalidIndexReturnBook_throwsParseException(String args) {
+        assertParseFailure(parser, args,
+                String.format(MESSAGE_INVALID_INDEX + newline + "%s", DeleteCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests parse method with invalid flag argument.
+     *
+     * @param args obtained from method {@code invalidFlagArgs}
+     */
+    @ParameterizedTest
+    @MethodSource("invalidFlagArgs")
+    public void parse_missingFlag_throwsParseException(String args) {
+        assertParseFailure(parser, args,
+                String.format(MESSAGE_MISSING_FLAG + newline + "%s", DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
This PR modifies the following: 
1. Show more helpful error messages for parsing errors for `DeleteCommandParser`.
2. Update parsing of flag arguments and their removal in `DeleteCommandParser`.
3. Add tests for `DeleteCommandParser`.
4. Add new message for missing index in Messages.java.