### PR TITLE
Fix name to only alphabets and enhance edit command message

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -20,5 +20,7 @@ public class Messages {
         "There is no cash on delivery field in Return order please check your input.";
     public static final String MESSAGE_ORDERS_LISTED_OVERVIEW = "%d order(s) listed!";
     public static final String MESSAGE_RETURN_ORDERS_LISTED_OVERVIEW = "%d return order(s) listed!";
-
+    public static final String MESSAGE_MISSING_INDEX = "Please provide an index!";
+    public static final String MESSAGE_INVALID_PREAMBLE = "Please make sure there is no value between "
+        + "the flag and the valid prefixes!";
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DELIVERY_TIMESTAMP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RETURN_TIMESTAMP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_WAREHOUSE;
@@ -47,30 +48,36 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the order identified "
-            + "by the index number used in the displayed order list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_TID + "TRANSACTION_ID] "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_DELIVERY_TIMESTAMP + "DELIVERY_DATE_&_TIME] "
-            + "[" + PREFIX_WAREHOUSE + "WAREHOUSE_LOCATION] "
-            + "[" + PREFIX_COD + "CASH_ON_DELIVERY] "
-            + "[" + PREFIX_COMMENT + "COMMENT] "
-            + "[" + PREFIX_TYPE + "TYPE_OF_ITEM] "
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_TID + "A0185837Q";
+        + "by the index number used in the displayed order list or return order list." + Messages.NEWLINE
+        + "Existing values will be overwritten by the input values." + Messages.NEWLINE
+        + "Example 1: " + COMMAND_WORD + " " + FLAG_ORDER_BOOK.getFlag() + " 1 "
+        + PREFIX_PHONE + "91234567 "
+        + PREFIX_TID + "A0185837Q" + Messages.NEWLINE
+        + "Example 2: " + COMMAND_WORD + " " + FLAG_RETURN_BOOK.getFlag() + " 1 "
+        + PREFIX_PHONE + "91234567 "
+        + PREFIX_TID + "A0185837Q" + Messages.NEWLINE
+        + "General format for editing orders: " + Messages.NEWLINE
+        + COMMAND_WORD + " FLAGS INDEX(must be a positive integer) "
+        + "[" + PREFIX_TID + "TRANSACTION_ID] "
+        + "[" + PREFIX_NAME + "NAME] "
+        + "[" + PREFIX_PHONE + "PHONE] "
+        + "[" + PREFIX_EMAIL + "EMAIL] "
+        + "[" + PREFIX_ADDRESS + "ADDRESS]" + Messages.NEWLINE
+        + "[" + PREFIX_DELIVERY_TIMESTAMP + "DELIVERY_DATE_TIME] OR "
+        + "[" + PREFIX_RETURN_TIMESTAMP + "RETURN_DATE_TIME] "
+        + "[" + PREFIX_WAREHOUSE + "WAREHOUSE_LOCATION] "
+        + "[" + PREFIX_COD + "CASH_ON_DELIVERY] (Only for Orders) "
+        + "[" + PREFIX_COMMENT + "COMMENT] "
+        + "[" + PREFIX_TYPE + "TYPE_OF_ITEM] ";
 
+    public static final String MESSAGE_DUPLICATE_PARCEL = "This parcel already exists in the list.";
     public static final String MESSAGE_EDIT_ORDER_SUCCESS = "Edited Order: %1$s";
     public static final String MESSAGE_EDIT_RETURN_ORDER_SUCCESS = "Edited Return Order: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PARCEL = "This parcel already exists in the list.";
     public static final String MULTIPLE_FLAGS_DETECTED = "Different flags detected, please check your input."
         + Messages.NEWLINE + "Format example: " + COMMAND_WORD + " -o 1 n/Alex" + Messages.NEWLINE
         + "OR " + COMMAND_WORD + " -r 1 n/Alex";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided."
+        + Messages.NEWLINE + "%1$s";
 
     private final Flag flag;
     private final Index index;
@@ -135,7 +142,7 @@ public class EditCommand extends Command {
         TypeOfItem updatedType = editParcelDescriptor.getItemType().orElse(orderToEdit.getItemType());
 
         return new Order(updatedTid, updatedName, updatedPhone, updatedEmail, updatedAddress, updateTimeStamp,
-                updatedWarehouse, updatedCod, updatedComment, updatedType);
+            updatedWarehouse, updatedCod, updatedComment, updatedType);
     }
 
     /**
@@ -143,7 +150,7 @@ public class EditCommand extends Command {
      * edited with {@code editParcelDescriptor}.
      */
     private static ReturnOrder createEditedReturnOrder(ReturnOrder returnOrderToEdit,
-                                                  EditParcelDescriptor editParcelDescriptor) {
+                                                       EditParcelDescriptor editParcelDescriptor) {
         assert returnOrderToEdit != null;
 
         TransactionId updatedTid = editParcelDescriptor.getTid().orElse(returnOrderToEdit.getTid());
@@ -165,7 +172,7 @@ public class EditCommand extends Command {
      *
      * @param parcelToEdit {@code Parcel} object that is going to be edited.
      * @param editedParcel {@code Parcel} object that has been edited.
-     * @param model {@code ModelManager} that represents the in-memory model of the order book data.
+     * @param model        {@code ModelManager} that represents the in-memory model of the order book data.
      * @return Returns a true if the Parcel is not editable, else false.
      * @throws CommandException Throws {@code CommandException} whenever a {@code Parcel} is duplicated.
      */
@@ -179,11 +186,11 @@ public class EditCommand extends Command {
      *
      * @param parcelToEdit {@code Parcel} object that is going to be edited.
      * @param editedParcel {@code Parcel} object that has been edited.
-     * @param model {@code ModelManager} that represents the in-memory model of the order book data.
+     * @param model        {@code ModelManager} that represents the in-memory model of the order book data.
      * @return Returns a {@code CommandResult} object representing the result of either editing an {@code Order} or
      * {@code ReturnOrder}.
      * @throws CommandException Throws {@code CommandException} whenever a {@code Parcel} is duplicated or if the
-     * {@code Parcel} type is invalid.
+     *                          {@code Parcel} type is invalid.
      */
     private CommandResult generalSetParcel(Parcel parcelToEdit, Parcel editedParcel, Model model)
         throws CommandException {
@@ -217,7 +224,7 @@ public class EditCommand extends Command {
         // state check
         EditCommand e = (EditCommand) other;
         return index.equals(e.index)
-                && editParcelDescriptor.equals(e.editParcelDescriptor);
+            && editParcelDescriptor.equals(e.editParcelDescriptor);
     }
 
     /**
@@ -261,8 +268,9 @@ public class EditCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(tid, name, phone, email, address, timeStamp, warehouse,
-                    cod, comment, itemType);
+                cod, comment, itemType);
         }
+
         public void setTid(TransactionId tid) {
             this.tid = tid;
         }
@@ -359,15 +367,15 @@ public class EditCommand extends Command {
             EditParcelDescriptor e = (EditParcelDescriptor) other;
 
             return getTid().equals(e.getTid())
-                    && getName().equals(e.getName())
-                    && getPhone().equals(e.getPhone())
-                    && getEmail().equals(e.getEmail())
-                    && getAddress().equals(e.getAddress())
-                    && getTimeStamp().equals(e.getTimeStamp())
-                    && getWarehouse().equals(e.getWarehouse())
-                    && getCash().equals(e.getCash())
-                    && getComment().equals(e.getComment())
-                    && getItemType().equals(e.getItemType());
+                && getName().equals(e.getName())
+                && getPhone().equals(e.getPhone())
+                && getEmail().equals(e.getEmail())
+                && getAddress().equals(e.getAddress())
+                && getTimeStamp().equals(e.getTimeStamp())
+                && getWarehouse().equals(e.getWarehouse())
+                && getCash().equals(e.getCash())
+                && getComment().equals(e.getComment())
+                && getItemType().equals(e.getItemType());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,9 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PREAMBLE;
 import static seedu.address.commons.core.Messages.MESSAGE_MISMATCH_FLAG_WITH_TIMESTAMP;
 import static seedu.address.commons.core.Messages.MESSAGE_MISSING_FLAG;
+import static seedu.address.commons.core.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_COD_FIELD_IN_RETURN_ORDER;
+import static seedu.address.commons.core.Messages.NEWLINE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMENT;
@@ -43,11 +46,13 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Flag flag = null;
 
+        checkForEmptyArgsAfterEditCommand(args);
+
         if (areFlagsPresent(args)) {
             flag = extractFlag(args);
             args = removeFlags(args);
         } else {
-            throw new ParseException(MESSAGE_MISSING_FLAG);
+            throw new ParseException(MESSAGE_MISSING_FLAG + NEWLINE + EditCommand.MESSAGE_USAGE);
         }
 
         assert(flag != null);
@@ -60,9 +65,12 @@ public class EditCommandParser implements Parser<EditCommand> {
         Index index;
 
         try {
+            checkForEmptyIndex(argMultimap.getPreamble());
+            checkForValidPreamble(argMultimap.getPreamble());
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format("%s" + NEWLINE + "%s",
+                pe.getMessage(), EditCommand.MESSAGE_USAGE));
         }
 
         checkPrefixMatchesFlag(argMultimap, flag);
@@ -84,7 +92,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         if (!editParcelDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(String.format(EditCommand.MESSAGE_NOT_EDITED, EditCommand.MESSAGE_USAGE));
         }
 
         return new EditCommand(index, editParcelDescriptor, flag);
@@ -275,5 +283,39 @@ public class EditCommandParser implements Parser<EditCommand> {
             editParcelDescriptor.setItemType(ParserUtil.parseItemType(argumentMultimap.getValue(PREFIX_TYPE).get()));
         }
         return editParcelDescriptor;
+    }
+
+    /**
+     * A checker method to see if user type only command word.
+     * @param args user input
+     * @throws ParseException throws exception of message usage to user if only command word is provided.
+     */
+    private void checkForEmptyArgsAfterEditCommand(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (args.split("\\s+").length == 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+    }
+
+    /**
+     * A checker method to see if user did not give any index
+     * @param string preamble of argmultimap
+     * @throws ParseException throws exception when index is empty.
+     */
+    private void checkForEmptyIndex(String string) throws ParseException {
+        if (string.isEmpty()) {
+            throw new ParseException(MESSAGE_MISSING_INDEX);
+        }
+    }
+
+    /**
+     * checks for valid index given.
+     * @param string preamble.
+     * @throws ParseException throws exception whenever user give more than just index in between the index and prefix
+     */
+    private void checkForValidPreamble(String string) throws ParseException {
+        if (string.split("\\s+").length > 1) {
+            throw new ParseException(MESSAGE_INVALID_PREAMBLE);
+        }
     }
 }

--- a/src/main/java/seedu/address/model/parcel/parcelattributes/Name.java
+++ b/src/main/java/seedu/address/model/parcel/parcelattributes/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain upper or lower alphabet characters and spaces, and it should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,9 +1,12 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PREAMBLE;
 import static seedu.address.commons.core.Messages.MESSAGE_MISMATCH_FLAG_WITH_TIMESTAMP;
 import static seedu.address.commons.core.Messages.MESSAGE_MISSING_FLAG;
+import static seedu.address.commons.core.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_COD_FIELD_IN_RETURN_ORDER;
+import static seedu.address.commons.core.Messages.NEWLINE;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.COD_DESC_AMY;
@@ -70,7 +73,6 @@ public class EditCommandParserTest {
         String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
     private static final Flag ORDER_FLAG = CliSyntax.FLAG_ORDER_BOOK;
-    private static final Flag RETURN_FLAG = CliSyntax.FLAG_RETURN_BOOK;
     private static final String ORDER_FLAG_INPUT = CliSyntax.FLAG_ORDER_BOOK.getFlag() + " ";
     private static final String RETURN_FLAG_INPUT = CliSyntax.FLAG_RETURN_BOOK.getFlag() + " ";
 
@@ -79,16 +81,24 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, ORDER_FLAG_INPUT + VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + NAME_DESC_AMY,
+            String.format(MESSAGE_MISSING_INDEX + NEWLINE + EditCommand.MESSAGE_USAGE));
 
         // no field specified
-        assertParseFailure(parser, ORDER_FLAG_INPUT + "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + "1",
+            String.format(EditCommand.MESSAGE_NOT_EDITED, EditCommand.MESSAGE_USAGE));
 
         // no index and no field specified
-        assertParseFailure(parser, ORDER_FLAG_INPUT, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         // missing flags
-        assertParseFailure(parser, VALID_ADDRESS_AMY, MESSAGE_MISSING_FLAG);
+        assertParseFailure(parser, VALID_ADDRESS_AMY,
+            MESSAGE_MISSING_FLAG + NEWLINE + EditCommand.MESSAGE_USAGE);
+
+        // no input
+        assertParseFailure(parser, "",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -120,16 +130,20 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, ORDER_FLAG_INPUT + "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + "-5" + NAME_DESC_AMY,
+            String.format(ParserUtil.MESSAGE_INVALID_INDEX + NEWLINE + EditCommand.MESSAGE_USAGE));
 
         // zero index
-        assertParseFailure(parser, ORDER_FLAG_INPUT + "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + "0" + NAME_DESC_AMY,
+            String.format(ParserUtil.MESSAGE_INVALID_INDEX + NEWLINE + EditCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, ORDER_FLAG_INPUT + "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + "1 some random string",
+            String.format(MESSAGE_INVALID_PREAMBLE + NEWLINE + EditCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, ORDER_FLAG_INPUT + "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, ORDER_FLAG_INPUT + "1 i/ string",
+            String.format(MESSAGE_INVALID_PREAMBLE + NEWLINE + EditCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/parcel/order/NameTest.java
+++ b/src/test/java/seedu/address/model/parcel/order/NameTest.java
@@ -31,12 +31,12 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("peter the 2nd")); // alphanumeric characters
+        assertFalse(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertFalse(Name.isValidName("12345")); // numbers only
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }
 }


### PR DESCRIPTION
1) changed name regex to \\p{alpha} instead of {alnum} to combat the issue of having alphabets as name
2) improve error message display for edit command.