### PR TITLE
Delete Command: Add message for return order list deletion

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -441,7 +441,10 @@ These messages are the following:
 1. `MESSAGE_DELETE_ORDER_SUCCESS` +
 Deleted Order: %1$s +
 
-2. `MESSAGE_INVALID_FLAG` +
+2. `MESSAGE_DELETE_RETURN_ORDER_SUCCESS` +
+Deleted Return Order: %1$s +
+
+3. `MESSAGE_INVALID_FLAG` +
 Invalid flag given! +
 
 ==== Interactions between Delete command and its associated objects

--- a/src/main/java/seedu/delino/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/delino/logic/commands/DeleteCommand.java
@@ -32,6 +32,7 @@ public class DeleteCommand extends Command {
             + NEWLINE + "Example: " + COMMAND_WORD + " -r" + " 1";
 
     public static final String MESSAGE_DELETE_ORDER_SUCCESS = "Deleted Order: %1$s";
+    public static final String MESSAGE_DELETE_RETURN_ORDER_SUCCESS = "Deleted Return Order: %1$s";
     public static final String MESSAGE_INVALID_FLAG = "Invalid flag given!";
 
     private static final Logger logger = LogsCenter.getLogger(DeleteCommand.class);
@@ -97,7 +98,7 @@ public class DeleteCommand extends Command {
 
         ReturnOrder orderToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteReturnOrder(orderToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_ORDER_SUCCESS, orderToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_RETURN_ORDER_SUCCESS, orderToDelete));
     }
 
     @Override

--- a/src/test/java/seedu/delino/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/delino/logic/commands/DeleteCommandTest.java
@@ -51,7 +51,7 @@ public class DeleteCommandTest {
         ReturnOrder returnOrderToDelete = model.getFilteredReturnOrderList().get(INDEX_FIRST_ORDER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ORDER, FLAG_RETURN_BOOK);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ORDER_SUCCESS, returnOrderToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_RETURN_ORDER_SUCCESS, returnOrderToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getOrderBook(), model.getReturnOrderBook(),
                 new UserPrefs());
@@ -98,7 +98,7 @@ public class DeleteCommandTest {
         ReturnOrder returnOrderToDelete = model.getFilteredReturnOrderList().get(INDEX_FIRST_ORDER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ORDER, FLAG_RETURN_BOOK);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_ORDER_SUCCESS, returnOrderToDelete);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_RETURN_ORDER_SUCCESS, returnOrderToDelete);
         Model expectedModel = new ModelManager(model.getOrderBook(), model.getReturnOrderBook(), new UserPrefs());
         expectedModel.deleteReturnOrder(returnOrderToDelete);
         showNoReturnOrder(expectedModel);


### PR DESCRIPTION
This PR modifies the following:
1. Add new message for the deletion of return orders
2. Update relevant tests
3. Update Developer Guide for delete command