### PR TITLE
Update Nearby Command to check for valid flag arguments

### DIFF
--- a/src/main/java/seedu/delino/logic/commands/NearbyCommand.java
+++ b/src/main/java/seedu/delino/logic/commands/NearbyCommand.java
@@ -21,6 +21,7 @@ import seedu.delino.model.parcel.order.Order;
 import seedu.delino.model.parcel.returnorder.ReturnOrder;
 
 //@@author JeremyLoh
+
 /**
  * Used to identify orders in the order book, return order book that belong to a given
  * postal sector or area.
@@ -167,7 +168,9 @@ public class NearbyCommand extends Command {
             return getAreaCommandResult(model);
         } else {
             logger.info("Invalid area given");
-            throw new CommandException(MESSAGE_FAILURE_AREA);
+            throw new CommandException(String.format("%s" + NEWLINE + "%s",
+                    MESSAGE_FAILURE_AREA,
+                    MESSAGE_USAGE));
         }
     }
 
@@ -187,13 +190,17 @@ public class NearbyCommand extends Command {
         if (isValidPostalSector(postalSector)) {
             Optional<String> generalLocation = getGeneralLocation(postalSector);
             if (generalLocation.isEmpty()) {
-                throw new CommandException(MESSAGE_FAILURE_POSTAL_SECTOR);
+                throw new CommandException(String.format("%s" + NEWLINE + "%s",
+                        MESSAGE_FAILURE_POSTAL_SECTOR,
+                        MESSAGE_USAGE));
             }
             showPostalSectors(model);
             return new CommandResult(String.format(MESSAGE_SUCCESS_POSTAL_SECTOR,
                     generalLocation.get()));
         } else {
-            throw new CommandException(MESSAGE_FAILURE_POSTAL_SECTOR);
+            throw new CommandException(String.format("%s" + NEWLINE + "%s",
+                    MESSAGE_FAILURE_POSTAL_SECTOR,
+                    MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/seedu/delino/logic/parser/NearbyCommandParser.java
+++ b/src/main/java/seedu/delino/logic/parser/NearbyCommandParser.java
@@ -1,8 +1,13 @@
 package seedu.delino.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.delino.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.delino.commons.core.Messages.MESSAGE_MISSING_FLAG;
+import static seedu.delino.logic.parser.CliSyntax.FLAG_ORDER_BOOK;
+import static seedu.delino.logic.parser.CliSyntax.FLAG_RETURN_BOOK;
 
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import seedu.delino.commons.core.LogsCenter;
 import seedu.delino.logic.commands.NearbyCommand;
@@ -13,7 +18,9 @@ import seedu.delino.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new NearbyCommand object.
  */
 public class NearbyCommandParser implements Parser<NearbyCommand> {
+    public static final String NEWLINE = System.lineSeparator();
     private static final Logger logger = LogsCenter.getLogger(NearbyCommandParser.class);
+
     /**
      * Parses the given {@code String} of arguments in the context of the NearbyCommand
      * and returns a NearbyCommand object for execution.
@@ -23,13 +30,50 @@ public class NearbyCommandParser implements Parser<NearbyCommand> {
      */
     @Override
     public NearbyCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        boolean isInvalid = trimmedArgs.length() == 0;
-        if (isInvalid) {
-            logger.info("Invalid arguments given for NearbyCommandParser");
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        try {
+            String trimmedArgs = args.trim();
+            if (isValidArg(trimmedArgs)) {
+                return new NearbyCommand(trimmedArgs);
+            }
+        } catch (ParseException pe) {
+            logger.info("Invalid Nearby Command arguments given for parsing");
+            throw new ParseException(String.format("%s" + NEWLINE + "%s", pe.getMessage(),
                     NearbyCommand.MESSAGE_USAGE));
         }
-        return new NearbyCommand(trimmedArgs);
+        logger.info("Invalid arguments given for NearbyCommandParser");
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                NearbyCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Checks if given {@code arg} has valid arguments
+     */
+    private boolean isValidArg(String arg) throws ParseException {
+        requireNonNull(arg);
+        if (arg.length() == 0) {
+            return false;
+        }
+        String[] argWords = arg.trim().split("\\s+");
+        boolean hasOrderFlag = hasRegex(FLAG_ORDER_BOOK.toString(), argWords);
+        boolean hasReturnFlag = hasRegex(FLAG_RETURN_BOOK.toString(), argWords);
+        if ((hasOrderFlag && hasReturnFlag) || (!hasOrderFlag && !hasReturnFlag)) {
+            throw new ParseException(MESSAGE_MISSING_FLAG);
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Check if the given {@code regex} is present (full match) in any argument in the given {@code searchValues}.
+     */
+    private boolean hasRegex(String regex, String[] searchValues) {
+        requireNonNull(regex);
+        requireNonNull(searchValues);
+        for (String value : searchValues) {
+            if (Pattern.matches(regex, value)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/seedu/delino/logic/commands/NearbyCommandTest.java
+++ b/src/test/java/seedu/delino/logic/commands/NearbyCommandTest.java
@@ -27,11 +27,13 @@ import seedu.delino.model.parcel.order.Order;
 import seedu.delino.model.parcel.returnorder.ReturnOrder;
 
 //@@author JeremyLoh
+
 /**
  * Contains integration tests (interactions with the Model) and unit test for
  * {@code NearbyCommand}.
  */
 class NearbyCommandTest {
+    private String newline = System.lineSeparator();
     private Model model = new ModelManager(getTypicalOrderBook(), getTypicalReturnOrderBook(), new UserPrefs());
     private Model expectedModel;
     private String invalidPostalSector;
@@ -235,14 +237,20 @@ class NearbyCommandTest {
 
     @Test
     void execute_invalidPostalSectorUnfilteredList_throwsCommandException() {
+        String expectedMessage = String.format("%s" + newline + "%s",
+                NearbyCommand.MESSAGE_FAILURE_POSTAL_SECTOR,
+                NearbyCommand.MESSAGE_USAGE);
         NearbyCommand nearbyCommand = new NearbyCommand(invalidPostalSector);
-        assertCommandFailure(nearbyCommand, model, NearbyCommand.MESSAGE_FAILURE_POSTAL_SECTOR);
+        assertCommandFailure(nearbyCommand, model, expectedMessage);
     }
 
     @Test
     void execute_invalidAreaUnfilteredList_throwsCommandException() {
+        String expectedMessage = String.format("%s" + newline + "%s",
+                NearbyCommand.MESSAGE_FAILURE_AREA,
+                NearbyCommand.MESSAGE_USAGE);
         NearbyCommand nearbyCommand = new NearbyCommand(invalidArea);
-        assertCommandFailure(nearbyCommand, model, NearbyCommand.MESSAGE_FAILURE_AREA);
+        assertCommandFailure(nearbyCommand, model, expectedMessage);
     }
 
     /**

--- a/src/test/java/seedu/delino/logic/parser/NearbyCommandParserTest.java
+++ b/src/test/java/seedu/delino/logic/parser/NearbyCommandParserTest.java
@@ -67,6 +67,7 @@ class NearbyCommandParserTest {
     @MethodSource("invalidArgs")
     void parse_invalidArgs_throwsParseException(String arg) {
         assertParseFailure(parser, arg,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, NearbyCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        NearbyCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
This PR modifies the following:
1. Update Nearby Command to check for valid flag arguments when parsing.
2. Update error messages to include Nearby Command usage information.
3. Update relevant tests.